### PR TITLE
Set the commit sha from the inputs instead of github context

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,4 +29,4 @@ runs:
         REPORT_PATH: ${{ inputs.report_path }}
         REPOSITORY_OWNER: "${{ env.REPOSITORY_OWNER }}"
         REPOSITORY: "${{ env.REPOSITORY_NAME }}"
-        COMMIT_SHA: "${{ github.sha }}"
+        COMMIT_SHA: "${{ inputs.sha }}"


### PR DESCRIPTION
Passing the sha as the input doesn't pass the wanted sha to the bash script.