### PR TITLE
feat: automatically delete container on completion

### DIFF
--- a/report.sh
+++ b/report.sh
@@ -1,6 +1,6 @@
 REPORT_PATH=$(pwd)/$REPORT_PATH
 
-docker run \
+docker run --rm \
   -e GH_ACCESS_TOKEN=$GH_ACCESS_TOKEN \
   -e REPO_OWNER=$REPOSITORY_OWNER \
   -e REPOSITORY=$REPOSITORY \


### PR DESCRIPTION
Simply added the `--rm` docker flag to automatically delete the container upon completion.

This is particularly useful when running the action on self-hosted runners. 

Closes #28