### PR TITLE
fix shell quoting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,10 +38,10 @@ runs:
   steps:
     - shell: bash
       run: |
-        export OWNER='$(echo '${{ github.repository }}' | awk -F / '{print $1}' | sed -e 's/:refs//')'
-        export REPO='$(echo '${{ github.repository }}' | awk -F / '{print $2}' | sed -e 's/:refs//')'
-        echo 'REPOSITORY_OWNER=$OWNER' >> $GITHUB_ENV
-        echo 'REPOSITORY_NAME=$REPO' >> $GITHUB_ENV
+        export OWNER="$(echo '${{ github.repository }}' | awk -F / '{print $1}' | sed -e 's/:refs//')"
+        export REPO="$(echo '${{ github.repository }}' | awk -F / '{print $2}' | sed -e 's/:refs//')"
+        echo "REPOSITORY_OWNER=$OWNER" >> $GITHUB_ENV
+        echo "REPOSITORY_NAME=$REPO" >> $GITHUB_ENV
     - shell: bash
       run: ${{ github.action_path }}/report.sh
       env:


### PR DESCRIPTION
PR https://github.com/joonvena/robotframework-reporter-action/pull/31 broke the bash shell script used to set the repository owner and name by accidentally using single quotes instead of double quotes resulting in the a failing of expansion of variables.


The problem would manifest when using `joonvena/robotframework-reporter-action@v2.5`, an example of the error is shown below:

```sh
Run joonvena/robotframework-reporter-action@v2.5
Run export OWNER='$(echo 'thin-edge/tedge-monit-setup' | awk -F / '{print $1}' | sed -e 's/:refs//')'
/home/runner/work/_temp/8a3a4c80-e9df-4cf9-aa36-e7e6386078e8.sh: line 1: export: `} | sed -e s/:refs//)': not a valid identifier
Error: Process completed with exit code 1.
```

Discovered on the following [build](https://github.com/thin-edge/tedge-monit-setup/actions/runs/9891571244/job/27322296697)